### PR TITLE
Register Signature on Behalf of Signer

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,7 @@
 			"**/*.tsx",
 			"**/*.js",
 			"**/*.jsx",
+			"**/package.json",
 			"!**/node_modules/**",
 			"!**/dist/**",
 			"!**/typechain-types/**",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,59 +1,61 @@
 {
-  "name": "harbour-contracts",
-  "version": "1.0.0",
-  "main": "index.js",
-  "directories": {
-    "test": "test"
-  },
-  "files": [
-    "src",
-    "deployments",
-    "typechain-types"
-  ],
-  "dependencies": {
-    "@account-abstraction/contracts": "^0.8.0",
-    "@openzeppelin/contracts": "^5.3.0",
-    "@safe-global/safe-contracts": "^1.4.1-2",
-    "@safe-global/safe-singleton-factory": "^1.0.44",
-    "yargs": "^18.0.0"
-  },
-  "devDependencies": {
-    "@noble/curves": "^1.9.6",
-    "@nomicfoundation/hardhat-toolbox": "^6.0.0",
-    "@nomicfoundation/hardhat-verify": "^2.0.14",
-    "@nomiclabs/hardhat-solhint": "^4.0.2",
-    "@safe-global/safe-deployments": "^1.37.36",
-    "@safe-global/safe-modules-deployments": "^2.2.10",
-    "@types/yargs": "^17.0.33",
-    "dotenv": "^16.6.0",
-    "ethers": "^6.14.4",
-    "hardhat": "^2.25.0",
-    "hardhat-deploy": "^1.0.4",
-    "hardhat-gas-reporter": "^2.3.0",
-    "jose": "^6.0.12",
-    "prettier": "^3.6.2",
-    "prettier-plugin-solidity": "^2.0.0",
-    "solhint": "^5.1.0"
-  },
-  "scripts": {
-    "build": "hardhat compile",
-    "deploy": "hardhat deploy-and-verify --network",
-    "lint:sol": "hardhat check",
-    "format:sol": "prettier --write --plugin=prettier-plugin-solidity '**/*.sol'",
-    "test": "hardhat test",
-    "test:bench": "hardhat test --grep '@bench'",
-    "hardhat:clean": "hardhat clean"
-  },
-  "keywords": [
-    "Safe",
-    "Harbour"
-  ],
-  "author": "",
-  "license": "LGPL-3.0-only",
-  "description": "",
-  "overrides": {
-    "@safe-global/safe-contracts": {
-      "ethers": "^6.14.4"
-    }
-  }
+	"name": "harbour-contracts",
+	"version": "1.0.0",
+	"main": "index.js",
+	"directories": {
+		"test": "test"
+	},
+	"files": [
+		"src",
+		"deployments",
+		"typechain-types"
+	],
+	"dependencies": {
+		"@account-abstraction/contracts": "^0.8.0",
+		"@openzeppelin/contracts": "^5.3.0",
+		"@safe-global/safe-contracts": "^1.4.1-2",
+		"@safe-global/safe-singleton-factory": "^1.0.44",
+		"yargs": "^18.0.0"
+	},
+	"devDependencies": {
+		"@noble/curves": "^1.9.6",
+		"@nomicfoundation/hardhat-toolbox": "^6.0.0",
+		"@nomicfoundation/hardhat-verify": "^2.0.14",
+		"@nomiclabs/hardhat-solhint": "^4.0.2",
+		"@safe-global/safe-deployments": "^1.37.36",
+		"@safe-global/safe-modules-deployments": "^2.2.10",
+		"@types/yargs": "^17.0.33",
+		"dotenv": "^16.6.0",
+		"ethers": "^6.14.4",
+		"hardhat": "^2.25.0",
+		"hardhat-deploy": "^1.0.4",
+		"hardhat-gas-reporter": "^2.3.0",
+		"jose": "^6.0.12",
+		"prettier": "^3.6.2",
+		"prettier-plugin-solidity": "^2.0.0",
+		"solhint": "^5.1.0"
+	},
+	"scripts": {
+		"build": "npm run build:sol && npm run build:ts",
+		"build:sol": "hardhat compile",
+		"build:ts": "tsc --noEmit",
+		"deploy": "hardhat deploy-and-verify --network",
+		"lint:sol": "hardhat check",
+		"format:sol": "prettier --write --plugin=prettier-plugin-solidity '**/*.sol'",
+		"test": "hardhat test",
+		"test:bench": "hardhat test --grep '@bench'",
+		"hardhat:clean": "hardhat clean"
+	},
+	"keywords": [
+		"Safe",
+		"Harbour"
+	],
+	"author": "",
+	"license": "LGPL-3.0-only",
+	"description": "",
+	"overrides": {
+		"@safe-global/safe-contracts": {
+			"ethers": "^6.14.4"
+		}
+	}
 }

--- a/contracts/src/interfaces/Constants.sol
+++ b/contracts/src/interfaces/Constants.sol
@@ -14,6 +14,9 @@ bytes32 constant DOMAIN_TYPEHASH = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c57
 // keccak256("SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)")
 bytes32 constant SAFE_TX_TYPEHASH = 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8;
 
+// keccak256("EncryptionKey(bytes32 context,bytes32 publicKey)")
+bytes32 constant ENCRYPTION_KEY_TYPEHASH = 0xc61c2d0b1f1942c20e1ecd68ca0337b62afaa25024fc73f2aad19b5696efb313;
+
 // The lower bound of the S value for a valid secp256k1 signature.
 // https://github.com/safe-global/safe-smart-account/blob/b115c4c5fe23dca6aefeeccc73d312ddd23322c2/contracts/Safe.sol#L100
 bytes32 constant SECP256K1_LOW_S_BOUND = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;

--- a/contracts/src/interfaces/Harbour.sol
+++ b/contracts/src/interfaces/Harbour.sol
@@ -7,6 +7,13 @@ import {EncryptionKey, SafeTransactionRegistrationHandle} from "./Types.sol";
 interface ISafeSecretHarbour {
     function registerEncryptionKey(bytes32 context, bytes32 publicKey) external;
 
+    function registerEncryptionKeyFor(
+        address signer,
+        bytes32 context,
+        bytes32 publicKey,
+        bytes calldata signature
+    ) external;
+
     function enqueueTransaction(
         uint256 chainId,
         address safe,

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "safe-harbour",
-  "private": true,
-  "workspaces": [
-    "contracts",
-    "webapp",
-    "validator"
-  ],
-  "scripts": {
-    "format": "biome format",
-    "format:fix": "biome format --fix",
-    "lint": "biome lint",
-    "lint:fix": "biome lint --fix",
-    "check": "biome check",
-    "test": "npm run test --workspaces"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.0.6",
-    "typescript": "^5.8.3"
-  }
+	"name": "safe-harbour",
+	"private": true,
+	"workspaces": [
+		"contracts",
+		"webapp",
+		"validator"
+	],
+	"scripts": {
+		"format": "biome format",
+		"format:fix": "biome format --fix",
+		"lint": "biome lint",
+		"lint:fix": "biome lint --fix",
+		"check": "biome check",
+		"test": "npm run test --workspaces"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.0.6",
+		"typescript": "^5.8.3"
+	}
 }


### PR DESCRIPTION
This PR adds a new feature to the secret harbour to allow any relayer to register an encryption key on bahalf of a signer. This makes it so a signer no longer has to execute the transaction to register the key.
