### PR TITLE
[Secret Harbour]: Dirty Form when Configuring Encryption

### DIFF
--- a/webapp/src/components/settings/SettingsForm.tsx
+++ b/webapp/src/components/settings/SettingsForm.tsx
@@ -93,7 +93,9 @@ function SettingsForm({
 	};
 
 	const onUseEncryption = () => {
-		setValue("harbourAddress", SECRET_HARBOUR_ADDRESS);
+		setValue("harbourAddress", SECRET_HARBOUR_ADDRESS, {
+			shouldDirty: true,
+		});
 	};
 
 	return (


### PR DESCRIPTION
The "use encryption" button is fixed to set the form to be "dirty", which allows saving. I hadn't noticed it before, as I was making the form "diry" by other means in my original testing.
