### PR TITLE
Fix International Harbour Regression

### DIFF
--- a/webapp/src/contexts/SessionContext.tsx
+++ b/webapp/src/contexts/SessionContext.tsx
@@ -177,10 +177,10 @@ function SessionProvider({ children }: { children: ReactNode }) {
 		[update, wallet, provider],
 	);
 
-	const disconnect = () => {
+	const disconnect = useCallback(() => {
 		setSession(null);
 		setError(null);
-	};
+	}, []);
 
 	const value = {
 		connected: session !== null,
@@ -203,10 +203,6 @@ function SessionProvider({ children }: { children: ReactNode }) {
 		error,
 	};
 
-	useEffect(() => {
-		connect();
-	}, [connect]);
-
 	return (
 		<SessionContext.Provider value={value}>{children}</SessionContext.Provider>
 	);
@@ -217,6 +213,13 @@ function useSession(): SessionValue {
 	if (value === null) {
 		throw new Error("useSession must be used within a SessionContext provider");
 	}
+
+	const { connect, disconnect } = value;
+	useEffect(() => {
+		connect();
+		return disconnect;
+	}, [connect, disconnect]);
+
 	return value;
 }
 

--- a/webapp/src/lib/harbour.ts
+++ b/webapp/src/lib/harbour.ts
@@ -53,7 +53,7 @@ function harbourAt(
 	address: string | undefined,
 	runner?: ContractRunner,
 ): Contract {
-	return new Contract(address ?? HARBOUR_ADDRESS, HARBOUR_ABI, runner);
+	return new Contract(address || HARBOUR_ADDRESS, HARBOUR_ABI, runner);
 }
 
 /** The address of the default Secret Harbour contract. */
@@ -814,7 +814,7 @@ async function fetchEncryptionKey(
 ): Promise<FetchedEncryptionKey | null> {
 	const harbour = await getHarbourContract(settings);
 	if (harbour.type !== "secret") {
-		throw new Error("Only Secret Harbour may register encryption keys");
+		return null;
 	}
 
 	const [context, publicKey] =


### PR DESCRIPTION
This fixes a couple issues with the International harbour path that was introduced with the Secret Harbour changes.

1. Visual :lock: bug where if you configure encrytion, go to the unconfigure encryption, then return to the queue, your session keys persist and the UI indicates that the queue is encrypted (even though it isn't). The UI would function as if the queue were not encrypted, so it is just a visual bug.
2. Fetching encryption keys should return `null` instead of throwing an error. This would cause issues where if an existing session were connected prior to disabling encryption.
3. Reseting the harbour address configuration leaves the `harbourAddress` configured as `""` instead of undefined. This causes issues as it is assumed that `harbourAddress: Address | undefined` in a couple of places when in fact it is `harbourAddress: Address | "" | undefined`. This is an annoying Ethers.js typing issue where `Address = string` (compared to Viem's <code>Address = `0x${string}`</code>

Anyway, it looks like the Secret Harbour changes introduced a few regressions (especially related to enabling/disabling encryption when not in a fresh state). I tested queuing transactions with both the International harbour (using Waku) and the Secret harbour, and going back and forth between the two - so things should be more stable now.

