### PR TITLE
[Web App]: Add Support for Transaction Builder Bundles

### DIFF
--- a/webapp/src/components/ActionCard.tsx
+++ b/webapp/src/components/ActionCard.tsx
@@ -2,6 +2,7 @@ import type { ToPathOption } from "@tanstack/react-router";
 import { Link } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react"; // For precise icon typing
 import { ArrowUpRight } from "lucide-react";
+import type { MouseEventHandler } from "react";
 import type { SafeId } from "@/lib/validators";
 
 /**
@@ -18,12 +19,14 @@ interface ActionCardProps {
 	ctaText: string;
 	/** The path to link to. Should be a registered route. */
 	to: ToPathOption;
-	/** Search parameters for the link. Must include 'safe' and 'chainId'. */
-	search: SafeId;
+	/** Search parameters for the link. Must at least include 'safe' and 'chainId'. */
+	search: SafeId & Record<string, unknown>;
 	/** Whether the action card should appear disabled. */
 	disabled?: boolean;
 	/** Tooltip text shown when the card is disabled to explain why. */
 	disabledTooltip?: string;
+	/** Optional additional handler when clicking the link. */
+	onClick?: MouseEventHandler<HTMLAnchorElement>;
 }
 
 /**
@@ -40,6 +43,7 @@ function ActionCard({
 	search,
 	disabled = false,
 	disabledTooltip,
+	onClick,
 }: ActionCardProps) {
 	const CTA = disabled ? (
 		<span
@@ -53,6 +57,7 @@ function ActionCard({
 			to={to}
 			search={search}
 			className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-black rounded-md hover:bg-gray-800 transition-colors"
+			onClick={onClick}
 		>
 			{ctaText}
 			<ArrowUpRight className="w-4 h-4" />

--- a/webapp/src/contexts/BatchTransactionsContext.tsx
+++ b/webapp/src/contexts/BatchTransactionsContext.tsx
@@ -25,6 +25,11 @@ interface BatchContextValue {
 	) => void;
 	clearBatch: (safeAddress: string, chainId: bigint) => void;
 	getBatch: (safeAddress: string, chainId: bigint) => BatchedTransaction[];
+	setBatch: (
+		safeAddress: string,
+		chainId: bigint,
+		txs: MetaTransaction[],
+	) => void;
 	totalCount: number;
 }
 
@@ -116,6 +121,20 @@ function BatchProvider({ children }: { children: ReactNode }) {
 		return batches[key] ?? [];
 	};
 
+	const setBatch = (
+		safeAddress: string,
+		chainId: bigint,
+		txs: MetaTransaction[],
+	) => {
+		const key = getKey(safeAddress, chainId);
+		setBatches((prev) => {
+			return {
+				...prev,
+				[key]: txs.map((tx) => ({ ...tx, safeAddress, chainId })),
+			};
+		});
+	};
+
 	const totalCount = Object.values(batches).reduce(
 		(sum, arr) => sum + arr.length,
 		0,
@@ -129,6 +148,7 @@ function BatchProvider({ children }: { children: ReactNode }) {
 				removeTransaction,
 				clearBatch,
 				getBatch,
+				setBatch,
 				totalCount,
 			}}
 		>

--- a/webapp/src/lib/txBundle.ts
+++ b/webapp/src/lib/txBundle.ts
@@ -28,14 +28,14 @@ const rawTransactionSchema = z.object({
 	to: ethereumAddressSchema,
 	value: numericStringSchema,
 	data: hexDataSchema,
-	contractMethod: z.undefined().optional(),
-	contractInputsValues: z.undefined().optional(),
+	contractMethod: z.null().optional(),
+	contractInputsValues: z.null().optional(),
 });
 
 const abiTransactionSchema = z.object({
 	to: ethereumAddressSchema,
 	value: numericStringSchema,
-	data: hexDataSchema.optional(),
+	data: hexDataSchema.nullable().optional(),
 	contractMethod: z.object({
 		inputs: z.array(contractMethodParameterSchema),
 		name: z.string(),

--- a/webapp/src/lib/txBundle.ts
+++ b/webapp/src/lib/txBundle.ts
@@ -91,10 +91,19 @@ function toMetaTransaction(tx: z.infer<typeof transactionSchema>) {
 }
 
 async function loadTxBundleFromFile(file: File): Promise<MetaTransaction[]> {
-	const raw = await readFile(file);
-	const json = JSON.parse(raw);
-	const bundle = bundleSchema.parse(json);
-	return bundle.transactions.map(toMetaTransaction);
+	try {
+		const raw = await readFile(file);
+		const json = JSON.parse(raw);
+		const bundle = bundleSchema.parse(json);
+		return bundle.transactions.map(toMetaTransaction);
+	} catch (err) {
+		if (err instanceof z.ZodError) {
+			throw new Error(
+				`Invalid transaction bundle format: ${err.errors[0].message}`,
+			);
+		}
+		throw err;
+	}
 }
 
 export { loadTxBundleFromFile };

--- a/webapp/src/lib/txBundle.ts
+++ b/webapp/src/lib/txBundle.ts
@@ -28,19 +28,19 @@ const rawTransactionSchema = z.object({
 	to: ethereumAddressSchema,
 	value: numericStringSchema,
 	data: hexDataSchema,
-	contractMethod: z.undefined(),
-	contractInputsValues: z.undefined(),
+	contractMethod: z.undefined().optional(),
+	contractInputsValues: z.undefined().optional(),
 });
 
 const abiTransactionSchema = z.object({
 	to: ethereumAddressSchema,
 	value: numericStringSchema,
-	data: z.optional(hexDataSchema),
+	data: hexDataSchema.optional(),
 	contractMethod: z.object({
 		inputs: z.array(contractMethodParameterSchema),
 		name: z.string(),
 		outputs: z.array(contractMethodParameterSchema),
-		payable: z.optional(z.boolean()),
+		payable: z.boolean().optional(),
 		stateMutability: z.string(),
 		type: z.literal("function"),
 	}),

--- a/webapp/src/lib/txBundle.ts
+++ b/webapp/src/lib/txBundle.ts
@@ -74,7 +74,7 @@ type RawTransaction = z.infer<typeof rawTransactionSchema>;
 type Transaction = z.infer<typeof transactionSchema>;
 
 function isRawTransaction(tx: Transaction): tx is RawTransaction {
-	return tx.contractMethod === undefined;
+	return !tx.contractMethod;
 }
 
 function toMetaTransaction(tx: z.infer<typeof transactionSchema>) {

--- a/webapp/src/lib/txBundle.ts
+++ b/webapp/src/lib/txBundle.ts
@@ -1,0 +1,100 @@
+import { ethers } from "ethers";
+import { z } from "zod";
+import type { MetaTransaction } from "@/lib/types";
+import {
+	ethereumAddressSchema,
+	hexDataSchema,
+	numericStringSchema,
+} from "@/lib/validators";
+
+const baseContractMethodParameterSchema = z.object({
+	name: z.string(),
+	type: z.string(),
+	internalType: z.string().optional(),
+});
+
+type ContractMethodParameter = z.infer<
+	typeof baseContractMethodParameterSchema
+> & {
+	components?: ContractMethodParameter[];
+};
+
+const contractMethodParameterSchema: z.ZodType<ContractMethodParameter> =
+	baseContractMethodParameterSchema.extend({
+		components: z.lazy(() => contractMethodParameterSchema.array().optional()),
+	});
+
+const rawTransactionSchema = z.object({
+	to: ethereumAddressSchema,
+	value: numericStringSchema,
+	data: hexDataSchema,
+	contractMethod: z.undefined(),
+	contractInputsValues: z.undefined(),
+});
+
+const abiTransactionSchema = z.object({
+	to: ethereumAddressSchema,
+	value: numericStringSchema,
+	data: z.optional(hexDataSchema),
+	contractMethod: z.object({
+		inputs: z.array(contractMethodParameterSchema),
+		name: z.string(),
+		outputs: z.array(contractMethodParameterSchema),
+		payable: z.optional(z.boolean()),
+		stateMutability: z.string(),
+		type: z.literal("function"),
+	}),
+	contractInputsValues: z.record(z.unknown()),
+});
+
+const transactionSchema = z.union([rawTransactionSchema, abiTransactionSchema]);
+
+const bundleSchema = z.object({
+	version: z.literal("1.0"),
+	chainId: numericStringSchema,
+	createdAt: z.number().int().nonnegative(),
+	meta: z.unknown(),
+	transactions: z.array(transactionSchema),
+});
+
+async function readFile(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.addEventListener("load", () => {
+			resolve(reader.result as string);
+		});
+		reader.addEventListener("error", () => {
+			reject(new Error("failed to read JSON file"));
+		});
+		reader.readAsText(file);
+	});
+}
+
+type RawTransaction = z.infer<typeof rawTransactionSchema>;
+type Transaction = z.infer<typeof transactionSchema>;
+
+function isRawTransaction(tx: Transaction): tx is RawTransaction {
+	return tx.contractMethod === undefined;
+}
+
+function toMetaTransaction(tx: z.infer<typeof transactionSchema>) {
+	const { to, value } = tx;
+	if (isRawTransaction(tx)) {
+		return { to, value, data: tx.data };
+	}
+	const iface = new ethers.Interface([tx.contractMethod]);
+	const params = tx.contractMethod.inputs.map(
+		(input) => tx.contractInputsValues[input.name],
+	);
+	const data = iface.encodeFunctionData(tx.contractMethod.name, params);
+	return { to, value, data };
+}
+
+async function loadTxBundleFromFile(file: File): Promise<MetaTransaction[]> {
+	const raw = await readFile(file);
+	const json = JSON.parse(raw);
+	const bundle = bundleSchema.parse(json);
+	return bundle.transactions.map(toMetaTransaction);
+}
+
+export { loadTxBundleFromFile };

--- a/webapp/src/routes/dashboard.tsx
+++ b/webapp/src/routes/dashboard.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import type { JsonRpcApiProvider } from "ethers";
 import { FileCode, HardHat, Link2, ScrollText } from "lucide-react";
-import { type ChangeEvent, type MouseEvent, useState } from "react";
+import { type ChangeEvent, createRef, type MouseEvent, useState } from "react";
 import { ActionCard } from "@/components/ActionCard";
 import { BackButton } from "@/components/BackButton";
 import { BalancesSection } from "@/components/BalancesSection";
@@ -42,6 +42,7 @@ function DashboardContent({
 	const [bundleError, setBundleError] = useState<Error | null>(null);
 	const navigate = useNavigate();
 	const { setBatch } = useBatch();
+	const fileInput = createRef<HTMLInputElement>();
 
 	const handleSendNative = () => {
 		navigate({
@@ -59,10 +60,7 @@ function DashboardContent({
 
 	const handleTxBundleClick = (event: MouseEvent<HTMLAnchorElement>) => {
 		event.preventDefault();
-
-		// TODO(nlordell): is this ideomatic React?
-		const input = document.querySelector("#tx-bundle-file") as HTMLInputElement;
-		input.click();
+		fileInput.current?.click();
 	};
 
 	const handleTxBundle = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -147,8 +145,8 @@ function DashboardContent({
 
 							{/* Hidden input element for opening a file dialog */}
 							<input
+								ref={fileInput}
 								type="file"
-								id="tx-bundle-file"
 								accept=".json"
 								style={{ display: "none" }}
 								onChange={handleTxBundle}


### PR DESCRIPTION
This PR adds support for parsing transaction builder JSON bundles to the current batch.

As a note, I wasn't sure the best way to implement a "file dialog" button, so comments are welcome. It was implemented this way in order to reuse the existing `ActionCard` component, while keeping it a link in order to indicate navigation will happen.

### Demo

[Screencast From 2025-10-15 15-35-33.webm](https://github.com/user-attachments/assets/38e2bd04-1c58-426b-bcba-edefac57ebd9)

